### PR TITLE
Repo name change

### DIFF
--- a/rm3614.md
+++ b/rm3614.md
@@ -1,5 +1,5 @@
-# ptjs
-Note: The repository for this project may be found [here](https://github.com/raghavmecheri/ptjs). As per the instructions on Gitter, the license badge has been added to this proposal file as well.<br /><br />
+# pytorchjs
+Note: The repository for this project may be found [here](https://github.com/raghavmecheri/pytorchjs). As per the instructions on Gitter, the license badge has been added to this proposal file as well.<br /><br />
 Note 2: The repository to my personal site set-up on Github Pages can be found [here](https://github.com/raghavmecheri/raghavmecheri.github.io) -- I did have one earlier, but this was a good opportunity to give the content a refresh and move it to Github Pages :) <br /><br />
 
 <img src="https://img.shields.io/github/license/raghavmecheri/coms4995?style=for-the-badge"></img><br/>


### PR DESCRIPTION
Changed repo name from ptjs to pytorchjs, due to ptjs being taken on npm :(